### PR TITLE
Fix /pr command to use issue URL instead of #xx

### DIFF
--- a/git_mcp/claude_commands/pr.md
+++ b/git_mcp/claude_commands/pr.md
@@ -39,7 +39,8 @@ Analyze the changes made thoroughly and consider multiple ways to present them c
    Use `create_merge_request()` to create the PR/MR with:
    - Craft a descriptive title linking to issue
    - Create comprehensive description that clearly explains the solution
-   - Closes #$ARGUMENTS in description
+   - **IMPORTANT**: In the description, use the full issue URL from `.claude/issue-$ARGUMENTS-*.md` instead of just `#$ARGUMENTS`
+   - Extract the URL using: `grep "URL:" .claude/issue-$ARGUMENTS-*.md | head -1 | cut -d' ' -f2`
    - Consider appropriate labels and reviewers
 
 4. **PR Description Template**


### PR DESCRIPTION
## Summary
Implements fix to use full issue URLs in PR descriptions as requested in issue https://github.com/yumeminami/git_mcp/issues/11

## Changes Made
- Updated `git_mcp/claude_commands/pr.md` with instruction to extract issue URL from `.claude/issue-*.md` files
- Added bash command guidance: `grep "URL:" .claude/issue-$ARGUMENTS-*.md | head -1 | cut -d' ' -f2`
- Maintains backward compatibility while enabling full issue URL usage in PR descriptions

## Testing
- Verified URL extraction command works with existing issue documentation
- Template preserves existing workflow while adding URL capability

## Documentation
- Updated PR command template with clear instructions for URL extraction

Closes https://github.com/yumeminami/git_mcp/issues/11